### PR TITLE
Update csrf.go

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -47,7 +47,7 @@ var CSRFFilter = func(c *revel.Controller, fc []revel.Filter) {
 		}
 	}
 
-	c.RenderArgs[fieldName] = realToken
+	c.ViewArgs[fieldName] = realToken
 
 	// See http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods
 	unsafeMethod := !safeMethods.MatchString(r.Method)


### PR DESCRIPTION
> go get github.com/cbonello/revel-csrf

の際に以下のエラーで怒られるのを修正

> github.com/cbonello/revel-csrf /var/golang/src/github.com/cbonello/revel-csrf/csrf.go:50: c.RenderArgs undefined (type *revel.Controller has no field or method RenderArgs)